### PR TITLE
fix: update CI composer install command for compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           ${{ runner.os }}-php-8.4-
 
     - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-suggest
+      run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist --optimize-autoloader
 
     - name: Copy environment file
       run: cp .env.example .env


### PR DESCRIPTION
Update the composer install command in CI workflow to use the exact same flags that the CI runner expects, ensuring compatibility between local development and CI environments.