### PR TITLE
Remove custom connection functionality from SSH Command Runner

- Remove Use Custom Connection button from page header
- Remove all custom connection form fields (hostname, port, username, identity file)
- Remove useCustomConnection property and related state management
- Simplify runCommand validation to only require selectedHost and command
- Remove toggleConnectionMode method and custom connection logic
- Remove custom connection tests (3 tests removed)
- Streamline interface to only use saved SSH hosts from database
- Clean up unused TextInput import
- All remaining tests pass (133 tests, 388 assertions)

### DIFF
--- a/tests/Feature/Filament/SshCommandRunnerTest.php
+++ b/tests/Feature/Filament/SshCommandRunnerTest.php
@@ -216,40 +216,10 @@ describe('SshCommandRunner Feature Tests', function () {
             ->assertSet('command', 'pwd');
     });
 
-    it('can toggle connection mode', function () {
-        $component = Livewire::test(SshCommandRunner::class);
-
-        expect($component->get('useCustomConnection'))->toBeFalse();
-
-        $component->call('toggleConnectionMode');
-
-        expect($component->get('useCustomConnection'))->toBeTrue();
-    });
-
     it('tracks command running state', function () {
         $component = Livewire::test(SshCommandRunner::class);
 
         expect($component->get('isCommandRunning'))->toBeFalse();
-    });
-
-    it('can use custom connection settings', function () {
-        Livewire::test(SshCommandRunner::class)
-            ->call('toggleConnectionMode')
-            ->assertSee('Hostname')
-            ->assertSee('Port')
-            ->assertSee('Username')
-            ->assertSee('Identity File (optional)');
-    });
-
-    it('validates custom connection fields when enabled', function () {
-        Livewire::test(SshCommandRunner::class)
-            ->call('toggleConnectionMode')
-            ->fillForm([
-                'command' => 'ls -la',
-                'hostname' => '',
-            ])
-            ->call('runCommand')
-            ->assertHasErrors(['hostname']);
     });
 
     it('shows error when no SSH hosts exist', function () {


### PR DESCRIPTION
## Summary
Remove custom connection functionality from SSH Command Runner

- Remove Use Custom Connection button from page header
- Remove all custom connection form fields (hostname, port, username, identity file)
- Remove useCustomConnection property and related state management
- Simplify runCommand validation to only require selectedHost and command
- Remove toggleConnectionMode method and custom connection logic
- Remove custom connection tests (3 tests removed)
- Streamline interface to only use saved SSH hosts from database
- Clean up unused TextInput import
- All remaining tests pass (133 tests, 388 assertions)

## Changes
- app/Filament/Pages/SshCommandRunner.php
- tests/Feature/Filament/SshCommandRunnerTest.php

🤖 Generated with [Claude Code](https://claude.ai/code)