### PR TITLE
Remove field labels, add custom placeholder, reduce textarea to 4 rows

### DIFF
--- a/app/Filament/Pages/SshCommandRunner.php
+++ b/app/Filament/Pages/SshCommandRunner.php
@@ -64,16 +64,17 @@ class SshCommandRunner extends Page
                     ->schema([
                         // Command textarea - left side
                         Textarea::make('command')
-                            ->label('Enter SSH Command(s)')
+                            ->hiddenLabel()
                             ->required()
-                            ->rows(5)
+                            ->rows(4)
                             ->placeholder('Enter SSH command(s) to execute...')
                             ->extraAttributes(['style' => 'resize: none;'])
                             ->columnSpan(1),
 
                         // SSH Host selector - right side
                         Select::make('selectedHost')
-                            ->label('Select SSH Host')
+                            ->hiddenLabel()
+                            ->placeholder('Select SSH Host')
                             ->options(function () {
                                 return SshHost::where('active', true)
                                     ->pluck('name', 'id')

--- a/tests/Feature/Filament/SshCommandRunnerTest.php
+++ b/tests/Feature/Filament/SshCommandRunnerTest.php
@@ -32,7 +32,7 @@ describe('SshCommandRunner Feature Tests', function () {
 
     it('displays page title correctly', function () {
         Livewire::test(SshCommandRunner::class)
-            ->assertSee('Enter SSH Command(s)');
+            ->assertSee('Enter SSH command(s) to execute...');
     });
 
     it('shows active SSH hosts in dropdown', function () {
@@ -66,7 +66,7 @@ describe('SshCommandRunner Feature Tests', function () {
 
     it('has command textarea field', function () {
         Livewire::test(SshCommandRunner::class)
-            ->assertSee('Enter SSH Command(s)');
+            ->assertSee('Enter SSH command(s) to execute...');
     });
 
     it('requires SSH host selection', function () {


### PR DESCRIPTION
## Summary
Remove field labels, add custom placeholder, reduce textarea to 4 rows

## Changes
- app/Filament/Pages/SshCommandRunner.php
- tests/Feature/Filament/SshCommandRunnerTest.php

🤖 Generated with [Claude Code](https://claude.ai/code)