### PR TITLE
Restore missing Debug label change and begin SSH settings recovery

### DIFF
--- a/app/Filament/Pages/SshCommandRunner.php
+++ b/app/Filament/Pages/SshCommandRunner.php
@@ -4,6 +4,7 @@ namespace App\Filament\Pages;
 
 use App\Models\SshHost;
 use App\Services\SshService;
+use App\Settings\SshSettings;
 use Exception;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
@@ -47,6 +48,18 @@ class SshCommandRunner extends Page
         $this->streamingOutput = '';
         $this->isCommandRunning = false;
         $this->debugOutput = '';
+
+        // Set default SSH host from settings
+        $settings = app(SshSettings::class);
+        $defaultHost = $settings->getDefaultSshHost();
+
+        if ($defaultHost) {
+            // Find the host by name and set as selected
+            $host = SshHost::where('name', $defaultHost)->where('active', true)->first();
+            if ($host) {
+                $this->selectedHost = (string) $host->id;
+            }
+        }
     }
 
     protected ?Ssh $currentSshProcess = null;
@@ -80,6 +93,18 @@ class SshCommandRunner extends Page
                                     return SshHost::where('active', true)
                                         ->pluck('name', 'id')
                                         ->toArray();
+                                })
+                                ->default(function () {
+                                    $settings = app(SshSettings::class);
+                                    $defaultHost = $settings->getDefaultSshHost();
+
+                                    if ($defaultHost) {
+                                        $host = SshHost::where('name', $defaultHost)->where('active', true)->first();
+                                        if ($host) {
+                                            return (string) $host->id;
+                                        }
+                                    }
+
                                 })
                                 ->afterStateUpdated(function ($state) {
                                     if ($state) {
@@ -127,9 +152,9 @@ class SshCommandRunner extends Page
                                     ])
                                         ->columnSpan(1),
 
-                                    // Verbose Debug toggle
+                                    // Debug toggle
                                     Toggle::make('verboseDebug')
-                                        ->label('Verbose Debug')
+                                        ->label('Debug')
                                         ->inline(true)
                                         ->columnSpan(1),
 

--- a/app/Settings/SshSettings.php
+++ b/app/Settings/SshSettings.php
@@ -18,6 +18,10 @@ class SshSettings
 
     public bool $strict_host_checking = false;
 
+    public ?string $default_ssh_host = null;
+
+    public ?string $default_ssh_key = null;
+
     public function __construct(array $attributes = [])
     {
         if (isset($attributes['home_dir'])) {


### PR DESCRIPTION
## Summary
Restore missing Debug label change and begin SSH settings recovery

## Changes
- app/Filament/Pages/SshCommandRunner.php
- app/Settings/SshSettings.php

🤖 Generated with [Claude Code](https://claude.ai/code)